### PR TITLE
Create SQL migrations

### DIFF
--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,0 +1,2 @@
+/target
+.env

--- a/rust/sql/000_init.sql
+++ b/rust/sql/000_init.sql
@@ -1,0 +1,22 @@
+begin;
+	create schema _versioning;
+
+	create table _versioning.migrations (
+		version int unique not null,
+		created_at timestamp with time zone not null default now()
+	);
+
+	insert into _versioning.migrations (version) values (0);
+
+	create function _versioning.migrate(version int) returns varchar as $$
+	declare
+		latest_version int;
+	begin
+		select max(m.version) from _versioning.migrations m into latest_version;
+		assert latest_version = version - 1, 'Applied migrations in the wrong order.';
+		insert into _versioning.migrations (version) values (version);
+		return 'ok';
+	end
+	$$ language plpgsql;
+
+commit;

--- a/rust/sql/001_create_stores.sql
+++ b/rust/sql/001_create_stores.sql
@@ -8,7 +8,7 @@ begin;
 		description text not null,
 		onlineshop boolean not null default false,
 		website_url varchar constraint website_len check (website_url is null or length(website_url) > 0),
-		email varchar not null,
+		email varchar not null constraint email_len check (length(email) > 0),
 		phone varchar constraint phone_len check (phone is null or length(phone) > 0),
 		address varchar not null constraint address_len check (length(address) > 0),
 		zip varchar not null constraint zip_len check (length(zip) > 0),

--- a/rust/sql/001_create_stores.sql
+++ b/rust/sql/001_create_stores.sql
@@ -1,0 +1,18 @@
+begin;
+
+	select _versioning.migrate(1);
+
+	create table stores (
+		id bigserial not null primary key,
+		name varchar not null constraint name_len check (length(name) > 0),
+		description text not null,
+		onlineshop boolean not null default false,
+		website_url varchar constraint website_len check (website_url is null or length(website_url) > 0),
+		email varchar not null,
+		phone varchar constraint phone_len check (phone is null or length(phone) > 0),
+		address varchar not null constraint address_len check (length(address) > 0),
+		zip varchar not null constraint zip_len check (length(zip) > 0),
+		city varchar not null constraint city_len check (length(city) > 0)
+	);
+
+commit;

--- a/rust/sql/migrate.sh
+++ b/rust/sql/migrate.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # source a .env file if it exists
-if [ -e .env ]; then
+if [ -r .env ]; then
 	. .env
 fi
 

--- a/rust/sql/migrate.sh
+++ b/rust/sql/migrate.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -euo pipefail
+
+# source a .env file if it exists
+if [ -e .env ]; then
+	. .env
+fi
+
+POSTGRES_URL=${POSTGRES_URL:?"Set POSTGRES_URL environment variable."}
+ls sql/*.sql | sort -n | xargs cat | psql ${POSTGRES_URL}


### PR DESCRIPTION
This hopefully makes the evolution of the database schema straight-forward. This is intended to be used with the `POSTGRES_URL` environment variable set. Alternatively a `.env` can be used. The `./sql/migrate.sh` script will apply all the outstanding patches to the database and make sure they are applied in order.